### PR TITLE
Fix for `bot.select` when using index number

### DIFF
--- a/M1/assets/sysdisk/startup.ms
+++ b/M1/assets/sysdisk/startup.ms
@@ -408,13 +408,13 @@ if bot then
 	end function
 	
 	bot.select = function(toolNameOrIndex)
+		inv = bot.inventory
 		if toolNameOrIndex isa number then
 			bot.currentToolIndex = toolNameOrIndex
 			print "Using " + inv[toolNameOrIndex].name + " (index " + toolNameOrIndex + ")"
 			return
 		end if
 		toolName = str(toolNameOrIndex).lower
-		inv = bot.inventory
 		for i in inv.indexes
 			if inv[i] and inv[i].name.lower == toolName then
 				bot.currentToolIndex = i


### PR DESCRIPTION
In the `bot.select` command, inv is used before it's assigned, resulting in the error:

`Runtime Error: Undefined Identifier: 'inv' is unknown in this context [line 411]`

Moving line 417 to be under line 410 fixes the issue and allows `bot.select` to use index numbers again instead of only item names.