### PR TITLE
Suggest fix for buying multiple bots issues.

### DIFF
--- a/M1/ModEntry.cs
+++ b/M1/ModEntry.cs
@@ -97,7 +97,7 @@ namespace Farmtronics
 						Debug.Log($"Shop item {index}: {item} with {item.Name}");
 						if (item.Name == "Catalogue" || (index>0 && shop.forSale[index-1].Name == "Flooring")) break;
 					}
-					var botForSale = new Bot(null);
+					var botForSale = new SalableBot();
 					shop.forSale.Insert(index, botForSale);
 					shop.itemPriceAndStock.Add(botForSale, new int[2] { 2500, int.MaxValue });	// sale price and available stock
 				}

--- a/M1/SalableBot.cs
+++ b/M1/SalableBot.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Farmtronics
+{
+    //This is a bot for sale in the shop. When the bot is purchased, it returns a new instance of the actual Bot class.
+    public class SalableBot : ISalable
+    {
+        static Texture2D botSprites;
+
+        public string DisplayName => Name;
+
+        public string Name => _name;
+
+
+        public string _name = "Bot";
+
+        public int Stack
+        {
+            get
+            {
+                return 1;
+            }
+            set
+            {
+            }
+        }
+
+        public SalableBot()
+        {
+            if (botSprites == null)
+            {
+                botSprites = ModEntry.helper.ModContent.Load<Texture2D>("assets/BotSprites.png");
+            }
+        }
+
+        public bool actionWhenPurchased()
+        {
+            return false;
+        }
+
+        public int addToStack(Item stack)
+        {
+            return 1;
+        }
+
+        public bool CanBuyItem(Farmer farmer)
+        {
+            //Pointless right now but could be useful for multiplayer
+            //return farmer.mailRecieved.Contains("FarmtronicsFirstBotMail"); //Should work, haven't tested.
+            return Game1.player.mailReceived.Contains("FarmtronicsFirstBotMail");
+        }
+
+        public bool canStackWith(ISalable other)
+        {
+            return false;
+        }
+
+        public void drawInMenu(SpriteBatch spriteBatch, Vector2 location, float scaleSize, float transparency, float layerDepth, StackDrawType drawStackNumber, Color color, bool drawShadow)
+        {
+            if (botSprites == null)
+            {
+                Debug.Log("Bot.drawInMenu: botSprites is null; bailing out");
+                return;
+            }
+
+            bool shouldDrawStackNumber = ((drawStackNumber == StackDrawType.Draw && this.maximumStackSize() > 1 && this.Stack > 1)
+                || drawStackNumber == StackDrawType.Draw_OneInclusive) && (double)scaleSize > 0.3 && this.Stack != int.MaxValue;
+
+            Rectangle srcRect = new Rectangle(0, 112, 16, 16);
+            spriteBatch.Draw(botSprites, location + new Vector2((int)(32f * scaleSize), (int)(32f * scaleSize)), srcRect, color * transparency, 0f,
+                new Vector2(8f, 8f) * scaleSize, 4f * scaleSize, SpriteEffects.None, layerDepth);
+
+            if (shouldDrawStackNumber)
+            {
+                var loc = location + new Vector2((float)(64 - Utility.getWidthOfTinyDigitString(this.Stack, 3f * scaleSize)) + 3f * scaleSize, 64f - 18f * scaleSize + 2f);
+                Utility.drawTinyDigits(this.Stack, spriteBatch, loc, 3f * scaleSize, 1f, color);
+            }
+        }
+
+        public string getDescription()
+        {
+            return "A programmable mechanical wonder.";
+        }
+
+        //Here was the main issue. On Items this returns a this.getOne()
+        public ISalable GetSalableInstance()
+        {
+            return new Bot(null);
+        }
+
+        public bool IsInfiniteStock()
+        {
+            return true;
+        }
+
+        public int maximumStackSize()
+        {
+            return 1;
+        }
+
+        public int salePrice()
+        {
+            return 50;
+        }
+
+        public bool ShouldDrawIcon()
+        {
+            return true;
+        }
+    }
+}

--- a/M1/SalableBot.cs
+++ b/M1/SalableBot.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Farmtronics
 {


### PR DESCRIPTION
`Items` implementing `ISalable` in StardewValley return a `getOne` when the player purchases an item from the shop.
By creating `SalableBot` we can add this to the list of items to sell instead of a `Bot` instance, and on purchase it creates a new instance of a `Bot` instead of calling `getOne` which attempts to duplicate a `Bot` that already exists.

+Victory photo
![Capture](https://user-images.githubusercontent.com/91914593/178040081-b6c007c3-0e62-4a34-862a-226d3b967678.PNG)
.