### PR TITLE
Migrate to SMAPI 4.0 & Add auto-updates for nuget packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,51 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Default options for .NET: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options#example-editorconfig-file
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+indent_style = tab
+trim_trailing_whitespace = false
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+###############################
+# C# Formatting Rules         #
+###############################
+# Resource: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = none
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = false
+csharp_indent_labels = no_change
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - directory: "/M1"
+    open-pull-requests-limit: 5
+    package-ecosystem: "nuget"
+    commit-message:
+      prefix: "dep nuget"
+    schedule:
+      interval: daily

--- a/.github/workflows/dep-auto-merge.yml
+++ b/.github/workflows/dep-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable_auto_merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto -s "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dep-auto-merge.yml
+++ b/.github/workflows/dep-auto-merge.yml
@@ -1,7 +1,11 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - ".NET CI"
+    types:
+      - completed
 
 permissions:
   pull-requests: write
@@ -11,11 +15,39 @@ jobs:
   enable_auto_merge:
     name: Enable auto-merge
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
 
     steps:
+      - name: Get PR URL
+        id: pr-url
+        uses: actions/github-script@v3
+        with:
+          result-encoding: string
+          script: |
+            const {owner, repo} = context.repo;
+            const pull_head_sha = '${{ github.event.workflow_run.head_sha }}';
+
+            const issue_number = await (async () => {
+              const pulls = await github.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pull_head_sha) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+
+            if (issue_number) {
+              core.info(`Using pull request ${issue_number}`);
+            } else {
+              return core.error(`No matching pull request found`);
+            }
+
+            return `${context.serverUrl}/${owner}/${repo}/pull/${issue_number}`;
+
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto -s "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ steps.pr-url.outputs.result }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,25 @@
+name: .NET CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Build
+      run: dotnet build
+
+    # - name: Test
+    #   run: dotnet test --no-build --verbosity normal

--- a/M1/Bot.cs
+++ b/M1/Bot.cs
@@ -102,7 +102,7 @@ namespace Farmtronics {
 			//Debug.Log($"Creating Bot({tileLocation}, {location?.Name}, {farmer?.Name}):\n{Environment.StackTrace}");
 
 			if (botSprites == null) {
-				botSprites = ModEntry.helper.Content.Load<Texture2D>("assets/BotSprites.png");
+				botSprites = ModEntry.helper.GameContent.Load<Texture2D>("assets/BotSprites.png");
 			}
 
 			Name = "Bot";
@@ -516,7 +516,7 @@ namespace Farmtronics {
 			Farmer who = farmer;
 
 			StardewValley.Object objectThatWasHeld = what.heldObject.Value;
-			if ((bool)what.readyForHarvest) {
+			if (what != null && what.readyForHarvest.Value) {
 				if (who.isMoving()) {
 					Game1.haltAfterCheck = false;
 				}
@@ -525,11 +525,11 @@ namespace Farmtronics {
 					int honey_type = -1;
 					string honeyName = "Wild";
 					int honeyPriceAddition = 0;
-					Crop c = Utility.findCloseFlower(who.currentLocation, what.tileLocation, 5, (Crop crop) => (!crop.forageCrop.Value) ? true : false);
+					Crop c = Utility.findCloseFlower(who.currentLocation, what.TileLocation, 5, (Crop crop) => (!crop.forageCrop.Value) ? true : false);
 					if (c != null) {
-						honeyName = Game1.objectInformation[c.indexOfHarvest].Split('/')[0];
+						honeyName = Game1.objectInformation[c.indexOfHarvest.Value].Split('/')[0];
 						honey_type = c.indexOfHarvest.Value;
-						honeyPriceAddition = Convert.ToInt32(Game1.objectInformation[c.indexOfHarvest].Split('/')[1]) * 2;
+						honeyPriceAddition = Convert.ToInt32(Game1.objectInformation[c.indexOfHarvest.Value].Split('/')[1]) * 2;
 					}
 					if (what.heldObject.Value != null) {
 						what.heldObject.Value.name = honeyName + " Honey";
@@ -584,11 +584,11 @@ namespace Farmtronics {
 				}
 				if (what.name.Equals("Crystalarium")) {
 					int mins = ModEntry.helper.Reflection.GetMethod(objectThatWasHeld, "getMinutesForCrystalarium").Invoke<int>(objectThatWasHeld.ParentSheetIndex);
-					what.minutesUntilReady.Value = mins;
+					what.MinutesUntilReady = mins;
 					what.heldObject.Value = (StardewValley.Object)objectThatWasHeld.getOne();
 				} else if (what.name.Contains("Tapper")) {
-					if (who.currentLocation.terrainFeatures.ContainsKey(what.tileLocation) && who.currentLocation.terrainFeatures[what.tileLocation] is Tree) {
-						(who.currentLocation.terrainFeatures[what.tileLocation] as Tree).UpdateTapperProduct(what, objectThatWasHeld);
+					if (who.currentLocation.terrainFeatures.ContainsKey(what.TileLocation) && who.currentLocation.terrainFeatures[what.TileLocation] is Tree) {
+						(who.currentLocation.terrainFeatures[what.TileLocation] as Tree).UpdateTapperProduct(what, objectThatWasHeld);
 					}
 				} else {
 					what.heldObject.Value = null;
@@ -597,10 +597,10 @@ namespace Farmtronics {
 				what.showNextIndex.Value = false;
 				if (what.name.Equals("Bee House") && !Game1.GetSeasonForLocation(who.currentLocation).Equals("winter")) {
 					what.heldObject.Value = new StardewValley.Object(Vector2.Zero, 340, null, canBeSetDown: false, canBeGrabbed: true, isHoedirt: false, isSpawnedObject: false);
-					what.minutesUntilReady.Value = Utility.CalculateMinutesUntilMorning(Game1.timeOfDay, 4);
+					what.MinutesUntilReady = Utility.CalculateMinutesUntilMorning(Game1.timeOfDay, 4);
 				} else if (what.name.Equals("Worm Bin")) {
 					what.heldObject.Value = new StardewValley.Object(685, Game1.random.Next(2, 6));
-					what.minutesUntilReady.Value = Utility.CalculateMinutesUntilMorning(Game1.timeOfDay, 1);
+					what.MinutesUntilReady = Utility.CalculateMinutesUntilMorning(Game1.timeOfDay, 1);
 				}
 				if (check_for_reload) {
 					what.AttemptAutoLoad(who);
@@ -690,7 +690,7 @@ namespace Farmtronics {
 					} else if (sign.displayItem.Value is Furniture) {
 						sign.displayType.Value = 5;
 					} else if (sign.displayItem.Value is StardewValley.Object) {
-						sign.displayType.Value = ((!(oneItem as StardewValley.Object).bigCraftable) ? 1 : 3);
+						sign.displayType.Value = ((!(oneItem as StardewValley.Object).bigCraftable.Value) ? 1 : 3);
 					}
 					return 1;
 				}

--- a/M1/Bot.cs
+++ b/M1/Bot.cs
@@ -7,15 +7,11 @@ using System.Collections.Generic;
 using System.Xml.Serialization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using StardewModdingAPI;
-using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Tools;
 using StardewValley.Network;
 using StardewValley.TerrainFeatures;
 using StardewValley.Objects;
-using System.Linq;
 
 namespace Farmtronics {
 	public class Bot : StardewValley.Object {

--- a/M1/BotUIMenu.cs
+++ b/M1/BotUIMenu.cs
@@ -5,8 +5,6 @@ It has several parts:
 	2. The bot inventory
 	3. A MiniScript console.
 */
-using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;

--- a/M1/ColorUtils.cs
+++ b/M1/ColorUtils.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 public static class ColorUtils {

--- a/M1/Console.cs
+++ b/M1/Console.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using StardewValley;
 using StardewModdingAPI;
 using StardewValley.Menus;
-using StardewValley.BellsAndWhistles;
 
 namespace Farmtronics {
 	public class Console : IClickableMenu, IKeyboardSubscriber {

--- a/M1/Console.cs
+++ b/M1/Console.cs
@@ -61,7 +61,7 @@ namespace Farmtronics {
 
 			screenArea = new Rectangle(20*drawScale, 18*drawScale, 160*drawScale, 120*drawScale);	// 640x480 (VGA)!
 
-			screenOverlay = ModEntry.helper.Content.Load<Texture2D>("assets/ScreenOverlay.png");
+			screenOverlay = ModEntry.helper.GameContent.Load<Texture2D>("assets/ScreenOverlay.png");
 			screenSrcR = new Rectangle(0, 0, 200, 160);
 
 			innerSrcR = new Rectangle(20, 18, 160, 120);
@@ -158,9 +158,9 @@ namespace Farmtronics {
 			// Most keys are handled through one of the misspelled IKeyboardSubscriber
 			// interface methods.  But not these:
 			switch (key) {
-			case Keys.Left:	
+			case Keys.Left: 
 			case Keys.Right:
-			case Keys.Down:	
+			case Keys.Down: 
 			case Keys.Up:
 			case Keys.Delete:
 				return;		// these are now handled via KeyWatchers in Update()

--- a/M1/Disk.cs
+++ b/M1/Disk.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 public abstract class Disk {
 

--- a/M1/Farmtronics.csproj
+++ b/M1/Farmtronics.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Joe Strout ($([System.DateTime]::UtcNow.ToString("s")))</Copyright>
+    <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Joe Strout ($([System.DateTime]::UtcNow.ToString("s")))</Copyright>
     <TargetFramework>net5.0</TargetFramework>
     <ReleaseVersion>1.0</ReleaseVersion>
     <ModFolderName>Farmtronics</ModFolderName>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Pathoschild.Stardew.ModBuildConfig" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig">
+      <Version>4.0.1</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/M1/FileUtils.cs
+++ b/M1/FileUtils.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Farmtronics;

--- a/M1/M1API.cs
+++ b/M1/M1API.cs
@@ -3,19 +3,14 @@ This static class implements the APIs that extend MiniScript with
 custom intrinsic functions/classes for use on the M-1.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Reflection;
 using Miniscript;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
-using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
-using StardewValley.BellsAndWhistles;
-using StardewValley.TerrainFeatures;
 
 
 

--- a/M1/M1API.cs
+++ b/M1/M1API.cs
@@ -1695,10 +1695,10 @@ namespace Farmtronics {
 				var loc = (Farm)Game1.getLocationFromName("Farm");
 				var weather = Game1.netWorldState.Value.GetWeatherForLocation(loc.GetLocationContext());
 				string result = "sunny";
-				if (weather.isLightning) result = "stormy";
-				else if (weather.isRaining) result = "raining";
-				else if (weather.isSnowing) result = "snowing";
-				else if (weather.isDebrisWeather) result = "windy";
+				if (weather.isLightning.Value) result = "stormy";
+				else if (weather.isRaining.Value) result = "raining";
+				else if (weather.isSnowing.Value) result = "snowing";
+				else if (weather.isDebrisWeather.Value) result = "windy";
 				worldInfo["weather"] = new ValString(result);
 			};
 

--- a/M1/Miniscript/MiniscriptLexer.cs
+++ b/M1/Miniscript/MiniscriptLexer.cs
@@ -7,7 +7,6 @@ Unless you’re writing a fancy MiniScript code editor, you probably don’t
 need to worry about this stuff. 
 
 */
-using System;
 using System.Collections.Generic;
 
 namespace Miniscript {

--- a/M1/Miniscript/MiniscriptTAC.cs
+++ b/M1/Miniscript/MiniscriptTAC.cs
@@ -11,7 +11,6 @@ deal with it directly (see MiniscriptInterpreter instead).
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Miniscript {

--- a/M1/MiniscriptUtils.cs
+++ b/M1/MiniscriptUtils.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Miniscript;
 using Microsoft.Xna.Framework;
 

--- a/M1/ModEntry.cs
+++ b/M1/ModEntry.cs
@@ -9,7 +9,7 @@ using StardewValley.BellsAndWhistles;
 
 namespace Farmtronics
 {
-	public class ModEntry : Mod, IAssetEditor {
+	public class ModEntry : Mod {
 		public static IModHelper helper;
 		public static ModEntry instance;
 
@@ -18,7 +18,6 @@ namespace Farmtronics
 		public override void Entry(IModHelper helper) {
 			instance = this;
 			ModEntry.helper = helper;
-			helper.Events.GameLoop.GameLaunched += this.OnGameLaunched;
 			helper.Events.GameLoop.ReturnedToTitle += this.OnReturnedToTitle;
 			helper.Events.Display.MenuChanged += this.OnMenuChanged;
 			helper.Events.GameLoop.UpdateTicking += UpdateTicking;
@@ -27,13 +26,11 @@ namespace Farmtronics
 			helper.Events.GameLoop.Saved += this.OnSaved;
 			helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
 			helper.Events.GameLoop.DayStarted += this.OnDayStarted;
+            Helper.Events.Content.AssetRequested += this.OnAssetRequested;
 			
 			print($"CurrentSavePath: {Constants.CurrentSavePath}");
 		}
 
-		private void OnGameLaunched(object sender, GameLaunchedEventArgs e) {
-			Helper.Content.AssetEditors.Add(this);
-		}
 
 		private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e) {
 			Bot.ClearAll();
@@ -167,27 +164,29 @@ namespace Farmtronics
 			shell.console.Present();
 		}
 
-		bool IAssetEditor.CanEdit<T>(IAssetInfo asset) {
-			return asset.Name.IsEquivalentTo("Data\\mail");
-		}
-
-		void IAssetEditor.Edit<T>(IAssetData asset) {
-			Debug.Log($"ModEntry.Edit(Mail)");
-			var data = asset.AsDictionary<string, string>().Data;
-			data["FarmtronicsFirstBotMail"] = "Dear @,"
-				+ "^^Congratulations!  You have been selected to receive a complementary FARMTRONICS BOT, the latest in farm technology!"
-				+ "^With this robotic companion, your days of toiling in the fields will soon be over."
-				+ "^Check your local stores for additional bots as needed.  Enjoy!"
-				+ "^^%item itemRecovery %%";
-			foreach (var msg in Game1.player.mailbox) {
-				Debug.Log($"mail in mailbox: {msg}");
-				if (msg == "FarmtronicsFirstBotMail") {
-					Debug.Log($"Changing recoveredItem from {Game1.player.recoveredItem} to Bot");
-					Game1.player.recoveredItem = new Bot(null);
-					break;
-				}
-			}
-
-		}
-	}
+        /// <inheritdoc cref="IContentEvents.AssetRequested" />
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnAssetRequested(object sender, AssetRequestedEventArgs e) {
+            if (e.NameWithoutLocale.IsEquivalentTo("Data/mail")) {
+                e.Edit(asset => {
+                    Debug.Log($"ModEntry.Edit(Mail)");
+                    var data = asset.AsDictionary<string, string>().Data;
+                    data["FarmtronicsFirstBotMail"] = "Dear @,"
+                        + "^^Congratulations!  You have been selected to receive a complementary FARMTRONICS BOT, the latest in farm technology!"
+                        + "^With this robotic companion, your days of toiling in the fields will soon be over."
+                        + "^Check your local stores for additional bots as needed.  Enjoy!"
+                        + "^^%item itemRecovery %%";
+                    foreach (var msg in Game1.player.mailbox) {
+                        Debug.Log($"mail in mailbox: {msg}");
+                        if (msg == "FarmtronicsFirstBotMail") {
+                            Debug.Log($"Changing recoveredItem from {Game1.player.recoveredItem} to Bot");
+                            Game1.player.recoveredItem = new Bot(null);
+                            break;
+                        }
+                    }
+                });
+            }
+        }
+    }
 }

--- a/M1/ModEntry.cs
+++ b/M1/ModEntry.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.BellsAndWhistles;
-using StardewValley.TerrainFeatures;
 
 
 namespace Farmtronics

--- a/M1/ModUtils.cs
+++ b/M1/ModUtils.cs
@@ -3,19 +3,7 @@
 	with mod (either StardewValley or SMAPI) classes easier.
 
 */
-using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using StardewModdingAPI;
-using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
 using StardewValley;
-using StardewValley.Tools;
-using StardewValley.Network;
-using StardewValley.TerrainFeatures;
-using StardewValley.Objects;
 
 namespace Farmtronics {
 	public static class ModUtils {

--- a/M1/RealFileDisk.cs
+++ b/M1/RealFileDisk.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using Farmtronics;
 

--- a/M1/Shell.cs
+++ b/M1/Shell.cs
@@ -4,12 +4,9 @@ It connects a MiniScript interpreter to the Console which interacts with
 the user. 
 */
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using StardewValley;
 using StardewModdingAPI;
-//using StardewValley.Menus;
 using Miniscript;
 using Microsoft.Xna.Framework;
 

--- a/M1/StringUtils.cs
+++ b/M1/StringUtils.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/M1/TextDisplay.cs
+++ b/M1/TextDisplay.cs
@@ -1,12 +1,9 @@
-﻿using MonoGame;
-using System;
+﻿using System;
 using System.IO;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using StardewValley;
-using StardewModdingAPI;
 
 namespace Farmtronics {
 

--- a/M1/TileInfo.cs
+++ b/M1/TileInfo.cs
@@ -5,16 +5,10 @@
 // It also contains some related methods to get info about objects and items,
 // which you may well find on a tile.
 
-using System;
 using System.Collections.Generic;
 using Miniscript;
 using Microsoft.Xna.Framework;
-using StardewModdingAPI;
-using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
 using StardewValley;
-using StardewValley.Menus;
-using StardewValley.BellsAndWhistles;
 using StardewValley.TerrainFeatures;
 using StardewValley.Locations;
 using StardewValley.Objects;

--- a/M1/ToDoManager.cs
+++ b/M1/ToDoManager.cs
@@ -1,9 +1,6 @@
 ﻿// This module detects and keeps track of the state of the "to-do" (quest) tasks,
 // mostly based on observing `print` output to the console.
-
-using System;
 using System.Collections.Generic;
-using StardewModdingAPI;
 using StardewValley;
 
 namespace Farmtronics {


### PR DESCRIPTION
This PR solves all deprecation warnings for SMAPI 4.0, adds auto-updates to nuget packages and improves the code formatting.

Code formatting was automatically done by vscode, but if you don't like that I'll revert that.

I updated SMAPI to the latest version and created a workflow to automatically merge any future updates after confirming the project still succeeds to build.

Migration was done by using the [wiki page](https://stardewvalleywiki.com/Modding:Migrate_to_SMAPI_4.0) as a reference and adjusting the code accordingly.

I plan on contributing another feature, but wanted to make sure the project builds without any warnings/errors first, which is how this PR came to be.