### PR TITLE
Fix FileNotFoundException introduced with #33

### DIFF
--- a/M1/Bot.cs
+++ b/M1/Bot.cs
@@ -102,7 +102,7 @@ namespace Farmtronics {
 			//Debug.Log($"Creating Bot({tileLocation}, {location?.Name}, {farmer?.Name}):\n{Environment.StackTrace}");
 
 			if (botSprites == null) {
-				botSprites = ModEntry.helper.GameContent.Load<Texture2D>("assets/BotSprites.png");
+				botSprites = ModEntry.helper.ModContent.Load<Texture2D>("assets/BotSprites.png");
 			}
 
 			Name = "Bot";

--- a/M1/Console.cs
+++ b/M1/Console.cs
@@ -61,7 +61,7 @@ namespace Farmtronics {
 
 			screenArea = new Rectangle(20*drawScale, 18*drawScale, 160*drawScale, 120*drawScale);	// 640x480 (VGA)!
 
-			screenOverlay = ModEntry.helper.GameContent.Load<Texture2D>("assets/ScreenOverlay.png");
+			screenOverlay = ModEntry.helper.ModContent.Load<Texture2D>("assets/ScreenOverlay.png");
 			screenSrcR = new Rectangle(0, 0, 200, 160);
 
 			innerSrcR = new Rectangle(20, 18, 160, 120);


### PR DESCRIPTION
Due to my previous changes `BotSprites.png` and `ScreenOverlay.png` couldn't be found, because I mixed `GameContent.Load` and `ModContent.Load` up.

(The quality of my next PR will definitely a lot better, sorry for that.)