### PR TITLE
Fix BotObject.IsEmptyWithoutInitialTools() not using the actual number of items & Add mod version to project

### DIFF
--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -78,8 +78,10 @@ namespace Farmtronics.Bot {
 				Items = Farmer.initialTools(),
 				MaxItems = 12
 			};
+			// NOTE: Make sure to not use farmer.Items.Count to get the actual number of items in the inventory
+			//		 Only UIMenu needs to use 'Count' to fill the remaining slots with null
 			ModEntry.instance.Monitor.Log($"TileLocation: {tileLocation} Position: {farmer.Position} Location: {farmer.currentLocation}");
-			ModEntry.instance.Monitor.Log($"Items: {farmer.Items.Count}/{farmer.MaxItems}");
+			ModEntry.instance.Monitor.Log($"Items: {farmer.numberOfItemsInInventory()}/{farmer.MaxItems}");
 		}
 
 		// This constructor is used for a Bot that is an Item, e.g., in inventory or as a mail attachment.
@@ -145,8 +147,8 @@ namespace Farmtronics.Bot {
 		}
 
 		private bool IsEmptyWithoutInitialTools() {
-			ModEntry.instance.Monitor.Log($"isEmptyWithoutInitialTools: items: {farmer.Items.Count}");
-			if (farmer.Items.Count > Farmer.initialTools().Count) return false;
+			ModEntry.instance.Monitor.Log($"isEmptyWithoutInitialTools: items: {farmer.numberOfItemsInInventory()}");
+			if (farmer.numberOfItemsInInventory() > Farmer.initialTools().Count) return false;
 			var copyItems = new List<Item>(farmer.Items);
 			Farmer.removeInitialTools(copyItems);
 			ModEntry.instance.Monitor.Log($"isEmptyWithoutInitialTools: without initial tools: {copyItems.Count}");
@@ -709,7 +711,7 @@ namespace Farmtronics.Bot {
 			}
 
 			// draw hat, if one is found in the last slot
-			if (farmer != null && farmer.MaxItems - 1 < farmer.Items.Count && farmer.Items[farmer.MaxItems -1] is Hat)
+			if (farmer != null && farmer.MaxItems - 1 < farmer.numberOfItemsInInventory() && farmer.Items[farmer.MaxItems -1] is Hat)
 				drawHat(spriteBatch, farmer.Items[farmer.MaxItems - 1] as Hat, position3, z + 0.0002f, alpha);
 		}
 

--- a/Farmtronics/Bot/UIMenu.cs
+++ b/Farmtronics/Bot/UIMenu.cs
@@ -127,10 +127,6 @@ namespace Farmtronics.Bot {
 				// No closing the menu while holding an item (issue #26)
 				return;
             }
-			else if (key == Keys.Escape && bot.shell.console.InputInProgress()) {
-				// About to close the menu - remove all null values from inventory
-				while (bot.inventory.Remove(null)) { }
-			}
 			bot.shell.console.receiveKeyPress(key);
 			if (key == Keys.Delete && heldItem != null && heldItem.canBeTrashed()) {
 				Utility.trashItem(heldItem);

--- a/Farmtronics/Farmtronics.csproj
+++ b/Farmtronics/Farmtronics.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Joe Strout ($([System.DateTime]::UtcNow.ToString("s")))</Copyright>
     <TargetFramework>net5.0</TargetFramework>
-    <ReleaseVersion>1.0</ReleaseVersion>
+    <ReleaseVersion>1.2.0</ReleaseVersion>
     <ModFolderName>Farmtronics</ModFolderName>
   </PropertyGroup>
 

--- a/Farmtronics/Farmtronics.csproj
+++ b/Farmtronics/Farmtronics.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <ReleaseVersion>1.2.0</ReleaseVersion>
     <ModFolderName>Farmtronics</ModFolderName>
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed yesterday you can close the bot menu without pressing `ESC` which leaves the inventory full of null items.
This would prevent you from picking up the bot until you would open the menu again and close it with `ESC`.

Now we use `farmer.numberOfItemsInInventory()` for everything when we need to check how many valid items are in the inventory. This also allows us to remove the menu exit step to remove all the null items, which is quite nice.

I also added the mod version number to `Farmtronics.csproj`, so it shares the same version with the manifest.

After performing a clean build I also noticed a strange error message when loading the mod. This issue is now also fixed with: 438ebf8