### PR TITLE
Try to find lost bot instances during warps

### DIFF
--- a/Farmtronics/Bot/BotManager.cs
+++ b/Farmtronics/Bot/BotManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Farmtronics.Multiplayer.Messages;
 using Farmtronics.Utils;
 using Microsoft.Xna.Framework;
@@ -26,12 +27,27 @@ namespace Farmtronics.Bot {
 			
 			foreach (var addInstance in findInstances)
 			{
+				// If maxAttempts were reached it's unlikely another attempt here could find this instance.
+				if (addInstance.HasGivenUp) continue;
+				
 				addInstance.Apply();
 			}
 			
-			if (lostInstances.Count == 0) {
+			if (lostInstances.All(instance => instance.HasGivenUp)) {
 				ModEntry.instance.Helper.Events.GameLoop.OneSecondUpdateTicking -= FindLostInstances;
 				addedFindEvent = false;
+			}
+		}
+
+		public static void FindLostInstancesOnWarp(object sender, WarpedEventArgs args) {
+			if (lostInstances.Count == 0) return;
+			
+			var findInstances = new List<AddBotInstance>(lostInstances);
+			
+			// Also retry all lost instances which reached maxAttempts
+			foreach (var addInstance in findInstances)
+			{
+				addInstance.Apply();
 			}
 		}
 		

--- a/Farmtronics/Bot/BotManager.cs
+++ b/Farmtronics/Bot/BotManager.cs
@@ -95,6 +95,7 @@ namespace Farmtronics.Bot {
 		public static void ClearAll() {
 			instances.Clear();
 			remoteInstances.Clear();
+			lostInstances.Clear();
 		}
 
 		public static List<BotObject> GetPlayerBotsInMap(long playerID, GameLocation inLocation = null) {

--- a/Farmtronics/M1/TileInfo.cs
+++ b/Farmtronics/M1/TileInfo.cs
@@ -252,6 +252,7 @@ namespace Farmtronics.M1 {
 				return result;
 			}
 
+#if DEBUG
 			// for debugging: check properties in various layers
 			string[] layers = {"Front", "Back", "Buildings", "Paths", "AlwaysFront"};
 			foreach (string layer in layers) {
@@ -261,8 +262,9 @@ namespace Farmtronics.M1 {
 				if (tile == null) continue;
 				foreach (var kv in tile.TileIndexProperties) {
 					Debug.Log($"layer {layer}, {kv.Key} = {kv.Value}");
-                }
-            }
+				}
+			}
+#endif
 
 			// If there is nothing at all of interest, return null rather
 			// than a map that contains only passable:true (and a type).

--- a/Farmtronics/ModEntry.cs
+++ b/Farmtronics/ModEntry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Farmtronics.Bot;
 using Farmtronics.M1;
 using Farmtronics.M1.Filesystem;
@@ -52,6 +51,7 @@ namespace Farmtronics
 			helper.Events.Multiplayer.PeerContextReceived += MultiplayerManager.OnPeerContextReceived;
 			helper.Events.Multiplayer.PeerConnected += MultiplayerManager.OnPeerConnected;
 			helper.Events.Multiplayer.PeerDisconnected += MultiplayerManager.OnPeerDisconnected;
+			helper.Events.Player.Warped += BotManager.FindLostInstancesOnWarp;
 			
 			Assets.Initialize(helper);
 			Monitor.Log($"Loaded fontAtlas with size {Assets.FontAtlas.Width}x{Assets.FontAtlas.Height}");

--- a/Farmtronics/Multiplayer/MultiplayerManager.cs
+++ b/Farmtronics/Multiplayer/MultiplayerManager.cs
@@ -4,7 +4,6 @@ using Farmtronics.Bot;
 using Farmtronics.M1;
 using Farmtronics.M1.Filesystem;
 using Farmtronics.Multiplayer.Messages;
-using Farmtronics.Utils;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 


### PR DESCRIPTION
This PR adds a new `OnPlayerWarped` event to allow `BotManager` to search (and hopefully find) lost bot instances in areas which were previously inaccessible to the player.
This is only really necessary for multiplayer clients, since they don't have access to the whole map and only know about active areas.

In addition to that I also added `#if DEBUG` around a debug logging part that currently quickly fills player logs, which makes issues a *little* harder to see.