### PR TITLE
Add dependabot auto-merge workflow & Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - directory: "/M1"
+  - directory: "/Farmtronics"
     open-pull-requests-limit: 5
     package-ecosystem: "nuget"
     commit-message:

--- a/.github/workflows/dependabot-PR-merge.yml
+++ b/.github/workflows/dependabot-PR-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge PRs
+name: Merge Dependabot PRs
 on:
   pull_request:
     paths-ignore:
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Enable auto-merge for dependency update PRs
-        run: gh pr merge --auto -s "$PR_URL"
+      - run: gh pr merge -s "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge PRs
+on:
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/**"
+
+permissions:
+  pull-requests: write
+  contents: write
+  checks: read
+
+jobs:
+  auto_merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge for dependency update PRs
+        run: gh pr merge --auto -s "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the working directory used by dependabot.yml and adds a new workflow that checks if a new PR was made by dependabot in which case it tries to automatically merge it.

Follow up from JoeStrout/miniscript#73

Since Farmtronics doesn't have any other CI to run tests or build the project automatically, I'm not sure if the auto-merge command will work correctly.
But if it doesn't you would only need to manually merge the dependabot PRs for miniscript to update the version here.