### PR TITLE
dep nuget: Update miniscript to 1.5.1-7e61f96

### DIFF
--- a/Farmtronics/Farmtronics.csproj
+++ b/Farmtronics/Farmtronics.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Miniscript" Version="1.0.0" />
+    <PackageReference Include="Miniscript" Version="1.5.1-7e61f96" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This should have been part of #57, but I forgot to add that.

This very small PR just updates the miniscript Nuget package to the latest pre-release!