### PR TITLE
Allow bot to pickup foragables

### DIFF
--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -377,6 +377,11 @@ namespace Farmtronics.Bot {
 				IList<Item> sourceItems = null;
 				if (obj is Chest chest) sourceItems = chest.items;
 				else if (obj is BotObject bot) sourceItems = bot.inventory;
+				else if(obj.isForage(farmer.currentLocation)) {
+					if (!farmer.couldInventoryAcceptThisItem(obj)) return false;
+					bool removedItem = farmer.currentLocation.Objects.Remove(obj.TileLocation);
+					if(removedItem) return AddItemToInventory(obj);
+				}
 				else Debug.Log($"Couldn't take any items from this object.");
 				if (sourceItems != null && slotNumber < sourceItems.Count && sourceItems[slotNumber] != null && AddItemToInventory(sourceItems[slotNumber])) {
 					Debug.Log($"Taking {sourceItems[slotNumber].DisplayName} from container");


### PR DESCRIPTION
Implements #60.

If no room in inventory, item won't be picked up.
If the item could not be removed meaning some error occurred then the item wont be picked up.
If the item was removed from the location, then add the item to the inventory.