### PR TITLE
Add github registry to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+registries:
+  github-nuget:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/JoeStrout/index.json
+    username: JoeStrout
+    password: ${{ secrets.NUGET_GH_TOKEN }}
+
 updates:
   - directory: "/Farmtronics"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
       prefix: "dep nuget"
     schedule:
       interval: daily
+    registries:
+      - github-nuget


### PR DESCRIPTION
Until now, Dependabot wasn't able to access Github Packages to check for miniscript updates.

This PR changes that by configuring a private registry for Nuget.

Before you merge this please make sure to add a new Dependabot secret with the name `NUGET_GH_TOKEN` and a [Github PAT](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) as the value.

Useful resources:
- [Storing credentials for Dependabot to use](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#storing-credentials-for-dependabot-to-use)
- [Configuring private Nuget feeds](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#nuget-feed)
- [Authenticating to Github Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages)