### PR TITLE
Update miniscript to 1.5.1-7ff7e28 & Address smaller issues

### DIFF
--- a/Farmtronics/Bot/BotFarmer.cs
+++ b/Farmtronics/Bot/BotFarmer.cs
@@ -1,6 +1,4 @@
-﻿using Farmtronics.Utils;
-using Microsoft.Xna.Framework;
-using StardewValley;
+﻿using StardewValley;
 using xTile.Dimensions;
 
 namespace Farmtronics.Bot

--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -11,7 +11,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewValley;
-using StardewValley.Locations;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
 using StardewValley.Tools;
@@ -382,7 +381,7 @@ namespace Farmtronics.Bot {
 					bool removedItem = farmer.currentLocation.Objects.Remove(obj.TileLocation);
 					if(removedItem) return AddItemToInventory(obj);
 				}
-				else Debug.Log($"Couldn't take any items from this object.");
+				else ModEntry.instance.Monitor.Log($"Couldn't take any items from this object.");
 				if (sourceItems != null && slotNumber < sourceItems.Count && sourceItems[slotNumber] != null && AddItemToInventory(sourceItems[slotNumber])) {
 					ModEntry.instance.Monitor.Log($"Taking {sourceItems[slotNumber].DisplayName} from container");
 					Utility.removeItemFromInventory(slotNumber, sourceItems);

--- a/Farmtronics/Bot/UIMenu.cs
+++ b/Farmtronics/Bot/UIMenu.cs
@@ -5,7 +5,7 @@ It has several parts:
 	2. The bot inventory
 	3. A MiniScript console.
 */
-using System.Linq;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;

--- a/Farmtronics/Farmtronics.csproj
+++ b/Farmtronics/Farmtronics.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Miniscript" Version="1.5.1" />
+    <PackageReference Include="Miniscript" Version="1.5.1-7ff7e28" />
   </ItemGroup>
 </Project>

--- a/Farmtronics/M1/Filesystem/OpenFile.cs
+++ b/Farmtronics/M1/Filesystem/OpenFile.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Text;
-using Farmtronics.Utils;
 
 namespace Farmtronics.M1.Filesystem {
 	/// <summary>

--- a/Farmtronics/M1/M1API.cs
+++ b/Farmtronics/M1/M1API.cs
@@ -2076,7 +2076,7 @@ namespace Farmtronics.M1 {
 		}
 
 		public override double Equality(Value rhs) {
-			return rhs is ValWrapper && ((ValWrapper)rhs).content == content ? 1 : 0;
+			return rhs is ValWrapper wrapper && wrapper.content == content ? 1 : 0;
 		}
 	}
 

--- a/Farmtronics/M1/M1API.cs
+++ b/Farmtronics/M1/M1API.cs
@@ -5,7 +5,6 @@ custom intrinsic functions/classes for use on the M-1.
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using Farmtronics.M1.Filesystem;
 using Farmtronics.M1.GUI;
 using Farmtronics.Multiplayer.Messages;

--- a/Farmtronics/M1/MathUtils.cs
+++ b/Farmtronics/M1/MathUtils.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 

--- a/Farmtronics/M1/PerPlayerData.cs
+++ b/Farmtronics/M1/PerPlayerData.cs
@@ -6,7 +6,6 @@
 // We keep around a singleton instance of this (instance), whiche any code that
 // has the need can read or update and the changes will get saved with the game.
 
-using System;
 using StardewValley;
 
 namespace Farmtronics {

--- a/Farmtronics/M1/Shell.cs
+++ b/Farmtronics/M1/Shell.cs
@@ -5,7 +5,6 @@ the user.
 */
 
 using System.Collections.Generic;
-using Farmtronics;
 using Farmtronics.Bot;
 using Farmtronics.M1.Filesystem;
 using Farmtronics.M1.GUI;

--- a/Farmtronics/ModEntry.cs
+++ b/Farmtronics/ModEntry.cs
@@ -3,8 +3,6 @@ using Farmtronics.Bot;
 using Farmtronics.M1;
 using Farmtronics.M1.Filesystem;
 using Farmtronics.Multiplayer;
-using Farmtronics.Utils;
-using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;

--- a/Farmtronics/Utils/PathUtils.cs
+++ b/Farmtronics/Utils/PathUtils.cs
@@ -2,7 +2,6 @@
 This module provides utilities for manipulating MiniScript file paths
 (which always use a '/' as the path separator, even on Windows).
 */
-using System;
 namespace Farmtronics.Utils {
 	public static class PathUtils {
 		/// <summary>

--- a/Farmtronics/Utils/StringUtils.cs
+++ b/Farmtronics/Utils/StringUtils.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
This PR updates the miniscript version to `1.5.1-7ff7e28` and removes a few unnecessary imports.

Aside from that build errors were fixed which were happening due to the usage of `Debug.Log` without importing the necessary dependency for it. The `Debug.Log` call was replaced with the intended logging mechanism for Stardew Valley mods.