### PR TITLE
Fix console drag issue in 1.6

### DIFF
--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -5,6 +5,8 @@ This class is a stardew valley Object subclass that represents a Bot.
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
 using Farmtronics.M1;
 using Farmtronics.Utils;
 using Microsoft.Xna.Framework;
@@ -163,7 +165,20 @@ namespace Farmtronics.Bot {
 			location.playSound("hammer");
 			return true;
 		}
+		
+		public bool UseBattery() {
+			if (farmer == null || inventory == null || farmer.CurrentTool == null) 
+				return false;
 
+			if (farmer.Items.Any(b => b is not null && b.QualifiedItemId.Equals("(O)787")))
+			{
+				farmer.stamina = Math.Min(Farmer.startingStamina, farmer.stamina + 100);
+				farmer.removeFirstOfThisItemFromInventory("(O)787");
+				return true;
+			}
+			return false;
+		}
+		
 		// Apply the currently-selected item as a tool (or weapon) on
 		// the square in front of the bot.
 		public void UseTool() {

--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -170,7 +170,7 @@ namespace Farmtronics.Bot {
 			if (farmer == null || inventory == null || farmer.CurrentTool == null) 
 				return false;
 
-			if (farmer.Items.Any(b => b is not null && b.QualifiedItemId.Equals("(O)787")))
+			if (farmer.Items.Any(b => b != null && b.QualifiedItemId.Equals("(O)787")))
 			{
 				farmer.stamina = Math.Min(Farmer.startingStamina, farmer.stamina + 100);
 				farmer.removeFirstOfThisItemFromInventory("(O)787");

--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -169,10 +169,17 @@ namespace Farmtronics.Bot {
 		public bool UseBattery() {
 			if (farmer == null || inventory == null || farmer.CurrentTool == null) 
 				return false;
-
-			if (farmer.Items.Any(b => b != null && b.QualifiedItemId.Equals("(O)787")))
+			
+			if (farmer.stamina >= Farmer.startingStamina) {
+				ModEntry.instance.Monitor.Log($"UseBattery called: Stamina already full, battery not used.", LogLevel.Trace);
+				return false;
+			}
+			
+			if (farmer.Items.Any(b => b != null && b.QualifiedItemId.Equals("(O)787"))) 
 			{
+				float oldStamina = farmer.stamina;
 				farmer.stamina = Math.Min(Farmer.startingStamina, farmer.stamina + 100);
+				ModEntry.instance.Monitor.Log($"UseBattery called: Stamina increased from {oldStamina} to {farmer.stamina}", LogLevel.Trace);
 				farmer.removeFirstOfThisItemFromInventory("(O)787");
 				return true;
 			}

--- a/Farmtronics/Bot/UIMenu.cs
+++ b/Farmtronics/Bot/UIMenu.cs
@@ -193,7 +193,8 @@ namespace Farmtronics.Bot {
 		bool inDragArea(int x, int y) {
 			// ModEntry.instance.Monitor.Log($"inDragArea: x={x} y={y}, in botInventoryBounds: {botInventoryBounds().Contains(x, y)}, in consoleBounds: {consoleBounds().Contains(x, y)}");
 			if (botInventoryBounds().Contains(x,y)) return false;
-			if (consoleBounds().Contains(x,y)) return false;
+			// commenting out the line below as console coordinates broke in SDV 1.6
+			//if (consoleBounds().Contains(x,y)) return false;
 
 			var playerInv = inventory;
 			Rectangle invRect = new Rectangle(playerInv.xPositionOnScreen, playerInv.yPositionOnScreen, width, height);

--- a/Farmtronics/M1/M1API.cs
+++ b/Farmtronics/M1/M1API.cs
@@ -720,6 +720,16 @@ namespace Farmtronics.M1 {
 				return result ? Intrinsic.Result.True : Intrinsic.Result.False;
 			};
 			meModule["harvest"] = f.GetFunc();
+			
+			f = Intrinsic.Create("");
+			f.code = (context, partialResult) => {
+				Shell sh = context.interpreter.hostData as Shell;
+				if (RequireBot(sh, "useBattery")) return Intrinsic.Result.Null;
+				
+				bool result = sh.bot.UseBattery();
+				return result ? Intrinsic.Result.True : Intrinsic.Result.False;
+			};
+			meModule["useBattery"] = f.GetFunc();
 
 			botProtectedKeys = new HashSet<string>();
 			foreach (Value key in meModule.Keys) {


### PR DESCRIPTION
Omitted checking if left click was made within console bounds as the console's calculated coordinates do not agree with the game's coordinates in 1.6. 

So far tested with no conflicts for clicks in:
- [x] Player inventory
- [x] Bot inventory
- [x] Menu close