### PR TITLE
Fix window dragging issue in 1.6

### DIFF
--- a/Farmtronics/Bot/UIMenu.cs
+++ b/Farmtronics/Bot/UIMenu.cs
@@ -6,6 +6,7 @@ It has several parts:
 	3. A MiniScript console.
 */
 
+using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -191,11 +192,10 @@ namespace Farmtronics.Bot {
 		/// Return whether the given screen position is in our draggable area.
 		/// </summary>
 		bool inDragArea(int x, int y) {
-			// ModEntry.instance.Monitor.Log($"inDragArea: x={x} y={y}, in botInventoryBounds: {botInventoryBounds().Contains(x, y)}, in consoleBounds: {consoleBounds().Contains(x, y)}");
+			//ModEntry.instance.Monitor.Log($"inDragArea: x={x} y={y}, in botInventoryBounds: {botInventoryBounds().Contains(x, y)}, in consoleBounds: {consoleBounds().Contains(x, y)}");
 			if (botInventoryBounds().Contains(x,y)) return false;
-			//if (consoleBounds().Contains(x,y)) return false;
-			// Note: Console bounds are not being calculated correctly in SDV 1.6
-			
+			if (consoleBounds().Contains(x+30,y-90)) return false;
+
 			var playerInv = inventory;
 			Rectangle invRect = new Rectangle(playerInv.xPositionOnScreen, playerInv.yPositionOnScreen, width, height);
 			if (invRect.Contains(x,y)) return false;

--- a/Farmtronics/Bot/UIMenu.cs
+++ b/Farmtronics/Bot/UIMenu.cs
@@ -193,8 +193,9 @@ namespace Farmtronics.Bot {
 		bool inDragArea(int x, int y) {
 			// ModEntry.instance.Monitor.Log($"inDragArea: x={x} y={y}, in botInventoryBounds: {botInventoryBounds().Contains(x, y)}, in consoleBounds: {consoleBounds().Contains(x, y)}");
 			if (botInventoryBounds().Contains(x,y)) return false;
-			if (consoleBounds().Contains(x,y)) return false;
-
+			//if (consoleBounds().Contains(x,y)) return false;
+			// Note: Console bounds are not being calculated correctly in SDV 1.6
+			
 			var playerInv = inventory;
 			Rectangle invRect = new Rectangle(playerInv.xPositionOnScreen, playerInv.yPositionOnScreen, width, height);
 			if (invRect.Contains(x,y)) return false;


### PR DESCRIPTION
I had to ~~comment out~~ _fudge_ the check for right-click within console bounds as the calculated coordinates do not agree with the game's reported coordinates in 1.6

Tested and working for clicks in
- [x] Bot inventory
- [x] Player Inventory
- [x] Close window 