### PR TITLE
Fixed bug where machine output isn't reset when taking item from machine

### DIFF
--- a/Farmtronics/Bot/BotObject.cs
+++ b/Farmtronics/Bot/BotObject.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.GameData.Crops;
+using StardewValley.GameData.Machines;
 using StardewValley.GameData.Objects;
 using StardewValley.Menus;
 using StardewValley.Objects;
@@ -382,8 +383,12 @@ namespace Farmtronics.Bot {
 					what.MinutesUntilReady = Utility.CalculateMinutesUntilMorning(Game1.timeOfDay, 1);
 				}
 				if (check_for_reload) {
+
 					what.AttemptAutoLoad(who);
 				}
+				MachineData? machineData = what.GetMachineData();
+				if (machineData != null && MachineDataUtility.TryGetMachineOutputRule(what, machineData, MachineOutputTrigger.OutputCollected, what.getOne(), null, what.Location, out MachineOutputRule outputCollectedRule, out _, out _, out _))
+					what.OutputMachine(machineData, outputCollectedRule, what.lastInputItem.Value, null, what.Location, false);
 				return true;
 
 			} else {


### PR DESCRIPTION
Trigger event outputcollected when an item is removed from a machine to allow custom machines that use this event as trigger to work. Example is automated mining drills (https://www.nexusmods.com/stardewvalley/mods/9291) 
<img width="337" alt="image" src="https://github.com/user-attachments/assets/58ec4797-510b-4c58-b9f2-7a3fb3f79887">
